### PR TITLE
Update namespace in math.fbs to fix inport issue

### DIFF
--- a/LA/Flatbuffers/Model/math.fbs
+++ b/LA/Flatbuffers/Model/math.fbs
@@ -1,4 +1,4 @@
-namespace Hayabusa.Util;
+namespace Hayabusa.Model;
 
 struct Vec3 {
     x: float;


### PR DESCRIPTION
The model files assume the default namespace