### PR TITLE
Update ccdata.fbs

### DIFF
--- a/SV/Flatbuffers/customization/ccdata.fbs
+++ b/SV/Flatbuffers/customization/ccdata.fbs
@@ -16,11 +16,26 @@ table Entry {
     anim_files: [string];
 }
 
+table Entry2 {
+    name: string;
+    entries: [Entry3];
+}
+
+table Entry3 {
+    name: string;
+	type: string;
+    unk0: [Entry4];
+}
+table Entry4 {
+    type: string;
+	enable: uint;
+}
+
 table CharacterCreationData {
     entries: [Entry];
     unk1: someTable2;
     unk2: uint;
-    unk3: string;
+    unk3: [Entry2];
 }
 
 root_type CharacterCreationData;


### PR DESCRIPTION
I encountered this error when using it

error:
  Unable to generate text for p0_hdw0005_00 (string contains non-utf8 bytes)

and using fbdrill noticed there was more tables on it
