### PR TITLE
Update trmdl.fbs

### DIFF
--- a/SV/Flatbuffers/model/trmdl.fbs
+++ b/SV/Flatbuffers/model/trmdl.fbs
@@ -44,7 +44,7 @@ table TRMDL {
     materials:[string];
     lods:[Lod];
     bounds: Bounds;
-    unk_vec:Vec4;
+    tex_spc_loc:Vec4;
     trltt: string;
     unk8: uint32;
     unk9: uint32;


### PR DESCRIPTION
Provides the 3d location in the texture space (in Blender, may be called something else in 3dMax).

Credit to Scarlett/SomeKitten & ElChicoEevee for the Pokémon Switch V2 (.TRMDL) script.