### PR TITLE
Static Map Icons schema

### DIFF
--- a/ZA/Flatbuffers/scene/map_icon_scene_point_0.fbs
+++ b/ZA/Flatbuffers/scene/map_icon_scene_point_0.fbs
@@ -1,0 +1,29 @@
+// This requires the trinity ScenePoint schema to work
+// It can be found here: https://github.com/pkZukan/PokeDocs/blob/main/SV/Flatbuffers/scene/trinity_ScenePoint.fbs
+// trinity ScenePoint requires common.fbs, which can be found here: https://github.com/pkZukan/PokeDocs/blob/main/SV/Flatbuffers/scene/common.fbs
+
+// This schema was meant for data\world\ik_scene\ui\map_icon_scene_point_\map_icon_scene_point_0.trscn
+// Which contains static map icon positions for things like shopping, pokemon centers, wild zones, rogue megas, etc.
+
+include "trinity_ScenePoint.fbs";
+
+namespace ikkaku_mapIconScenePoint;
+
+table ikkaku_mapIconData {
+    point_type: string;
+    data: [ubyte] (nested_flatbuffer: "Titan.TrinityScene.trinity_ScenePoint");
+    unk1: byte;
+    unk2: uint;
+}
+
+table ikkaku_mapIcons {
+    name: string;
+    node_type: string;
+    unk1: uint32;
+    unk2: uint32;
+    points: [ikkaku_mapIconData];
+    unk3: uint;
+    unk4: bool;
+}
+
+root_type ikkaku_mapIcons;


### PR DESCRIPTION
This schema is meant for data\world\ik_scene\ui\map_icon_scene_point_\map_icon_scene_point_0.trscn, which contains static map icon positions for things like shopping, pokemon centers, wild zones, rogue megas, etc.

This is my first time attempting to contribute to this repo. Let me know if there is anything that needs to be changed. I hope to continue to contribute in the future.

Below is a preview of the data I was able to extract using this schema (barring things like point names):
<img width="985" height="829" alt="image" src="https://github.com/user-attachments/assets/7d9812c2-2ba5-4059-beb8-1afc8d7b4af6" />
